### PR TITLE
fix(source-map-uploader): Only find corresponding source if a map file was found

### DIFF
--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -41,11 +41,11 @@ class BugsnagSourceMapUploaderPlugin {
         const map = chunk.files.find(file => /.+\.map(\?.*)?$/.test(file))
 
         // find a corresponding source file in the chunk
-        const source = chunk.files.find(file => file === map.replace('.map', ''))
+        const source = map ? chunk.files.find(file => file === map.replace('.map', '')) : null
 
         if (!source || !map) {
-          console.warn(`${LOG_PREFIX} no source/map pair found for chunk "${chunk.name}"`)
-          return cb()
+          console.warn(`${LOG_PREFIX} no source/map pair found for chunk "${chunk.id}"`)
+          return null
         }
 
         return {
@@ -59,7 +59,7 @@ class BugsnagSourceMapUploaderPlugin {
         }
       }
 
-      const sourceMaps = stats.chunks.map(chunkToSourceMapDescriptor)
+      const sourceMaps = stats.chunks.map(chunkToSourceMapDescriptor).filter(Boolean)
       parallel(sourceMaps.map(sm => cb => {
         console.log(`${LOG_PREFIX} uploading sourcemap for "${sm.url}"`)
         upload(this.getUploadOpts(sm), cb)


### PR DESCRIPTION
In cases where no .map files are found for a chunk, attempting to replace the map file's name threw
an error because map=null (and the code expected a string). Additionally, calling cb() when no map/file
is found causes cb() to be called multiple times because this function is run for each chunk. This is
fixed by returning null and then filtering out falsey values from the result of the async map.

---

I ran into issues around this area of then code when attempting to debug #3. These adjustments mean I am able to build a hello world nextjs app and upload the sourcemaps.