### PR TITLE
Tolerate a leading slash in the webpack chunk names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-bugsnag-plugins",
-  "version": "1.2.0",
+  "version": "1.2.1-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-bugsnag-plugins",
-  "version": "1.2.0",
+  "version": "1.2.1-0",
   "description": "Webpack plugins for common Bugsnag actions",
   "keywords": [
     "bugsnag",

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -54,7 +54,9 @@ class BugsnagSourceMapUploaderPlugin {
           url: resolve(
             // ensure publicPath has a trailing slash
             publicPath.replace(/[^/]$/, '$&/'),
-            // ensure source doesn't have a leading slash
+            // ensure source doesn't have a leading slash (sometimes it does, e.g.
+            // in laravel-mix, but this throws off the url resolve() call) see issue
+            // for more detail: https://github.com/bugsnag/webpack-bugsnag-plugins/issues/11
             source.replace(/^\//, '')
           ).toString()
         }

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -54,7 +54,8 @@ class BugsnagSourceMapUploaderPlugin {
           url: resolve(
             // ensure publicPath has a trailing slash
             publicPath.replace(/[^/]$/, '$&/'),
-            source
+            // ensure source doesn't have a leading slash
+            source.replace(/^\//, '')
           ).toString()
         }
       }


### PR DESCRIPTION
Laravel mix sets webpack config in a way that results in chunk output paths having a leading slash. This causes the url resolve function to resolve from the url root, not relatively, as described in #11. This change strips a leading slash from the output path before resolving the url.

Fixes #11.