### PR TITLE
fix: Handle missing source map asset

### DIFF
--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -42,7 +42,7 @@ class BugsnagSourceMapUploaderPlugin {
 
         return maps.map(map => {
           // for each *.map file, find a corresponding source file in the chunk
-          const source = map ? chunk.files.find(file => file === map.replace('.map', '')) : null
+          const source = chunk.files.find(file => file === map.replace('.map', ''))
 
           if (!source) {
             console.warn(`${LOG_PREFIX} no corresponding source found for "${map}" in chunk "${chunk.id}"`)

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -44,8 +44,17 @@ class BugsnagSourceMapUploaderPlugin {
           // for each *.map file, find a corresponding source file in the chunk
           const source = map ? chunk.files.find(file => file === map.replace('.map', '')) : null
 
-          if (!source || !map) {
-            console.warn(`${LOG_PREFIX} no source/map pair found for chunk "${chunk.id}"`)
+          if (!source) {
+            console.warn(`${LOG_PREFIX} no corresponding source found for "${map}" in chunk "${chunk.id}"`)
+            return null
+          }
+
+          if (!compilation.assets[source]) {
+            console.debug(`${LOG_PREFIX} source asset not found in compilation output "${source}"`)
+          }
+
+          if (!compilation.assets[map]) {
+            console.debug(`${LOG_PREFIX} source map not found in compilation output "${map}"`)
             return null
           }
 

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -51,6 +51,7 @@ class BugsnagSourceMapUploaderPlugin {
 
           if (!compilation.assets[source]) {
             console.debug(`${LOG_PREFIX} source asset not found in compilation output "${source}"`)
+            return null
           }
 
           if (!compilation.assets[map]) {


### PR DESCRIPTION
Sometimes source maps exist in the chunk, but are not written to disk so do not appear in the compilation assets. This change checks for the existence of the asset before proceeding to use it.

Fixes #18