### PR TITLE
feat: Add whitelist of extensions to upload (defaults to [ '.js' ] )

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Upload your application's sourcemap(s) to Bugsnag. When Webpack is done producin
   - `appVersion: string` the version of the application you are building
   - `overwrite: boolean` whether you want to overwrite previously uploaded sourcemaps
   - `endpoint: string` post the build payload to a URL other than the default (`https://upload.bugsnag.com`)
+  - `extensions: string[]` a list of bundle file extensions to upload source maps for (default `[ '.js' ]`)
 
 #### Usage
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Upload your application's sourcemap(s) to Bugsnag. When Webpack is done producin
   - `appVersion: string` the version of the application you are building
   - `overwrite: boolean` whether you want to overwrite previously uploaded sourcemaps
   - `endpoint: string` post the build payload to a URL other than the default (`https://upload.bugsnag.com`)
-  - `extensions: string[]` a list of bundle file extensions to upload source maps for (default `[ '.js' ]`)
+  - `ignoredBundleExtensions: string[]` a list of bundle file extensions which shouldn't be uploaded (default `[ '.css' ]`)
 
 #### Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -219,9 +219,9 @@
       }
     },
     "bugsnag-sourcemaps": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/bugsnag-sourcemaps/-/bugsnag-sourcemaps-1.0.5.tgz",
-      "integrity": "sha512-9MV4c7y4xFXzK9rl8MSB9k0nNXUDnpt3VcrKZhHscXShfWZ6eY18JQ2QNIU+UZGHe2e9n23u+OonxxEmrAVE3Q==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/bugsnag-sourcemaps/-/bugsnag-sourcemaps-1.0.7.tgz",
+      "integrity": "sha512-krf7A2pz1Jr5k9TAwl9sLNX0KCc+ermC4wDshh+45ADzZzHEYCjYjx+QF1hQxAB19HBcfDTIEJ1O5dgmHgVJmQ==",
       "requires": {
         "graceful-fs": "^4.1.11",
         "listr": "^0.12.0",
@@ -238,7 +238,7 @@
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "requires": {
             "camelcase": "^2.0.0",
@@ -260,7 +260,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -277,7 +277,7 @@
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "requires": {
             "camelcase-keys": "^2.0.0",
@@ -305,7 +305,7 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "parse-json": {
@@ -355,7 +355,7 @@
             },
             "load-json-file": {
               "version": "2.0.0",
-              "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
               "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
               "requires": {
                 "graceful-fs": "^4.1.2",
@@ -612,9 +612,9 @@
       }
     },
     "date-fns": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
-      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "debug": {
       "version": "2.6.9",
@@ -1111,7 +1111,7 @@
     "fast-json-parse": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
-      "integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw=="
+      "integrity": "sha1-Q+XGHuTvqSZWMwRrdw+2gqdXfE0="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -1127,7 +1127,7 @@
     "fast-safe-stringify": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-1.2.3.tgz",
-      "integrity": "sha512-QJYT/i0QYoiZBQ71ivxdyTqkwKkQ0oxACXHYxH2zYHJEgzi2LsbjgvtzTbLi1SZcF190Db2YP7I7eTsU2egOlw=="
+      "integrity": "sha1-n+IsN/svf4bwa48AQ3fb+PHue8E="
     },
     "figures": {
       "version": "1.7.0",
@@ -1151,7 +1151,7 @@
     "find-nearest-file": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-nearest-file/-/find-nearest-file-1.1.0.tgz",
-      "integrity": "sha512-NMsS0ITOwpBPrHOyO7YUtDhaVEGUKS0kBJDVaWZPuCzO7JMW+uzFQQVts/gPyIV9ioyNWDb5LjhHWXVf1OnBDA=="
+      "integrity": "sha1-4pRBdAMpogFfdlX67Ne4XgLK1oY="
     },
     "find-root": {
       "version": "1.1.0",
@@ -1183,7 +1183,7 @@
     "flatstr": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.8.tgz",
-      "integrity": "sha512-YXblbv/vc1zuVVUtnKl1hPqqk7TalZCppnKE7Pr8FI/Rp48vzckS/4SJ4Y9O9RNiI82Vcw/FydmtqdQOg1Dpqw=="
+      "integrity": "sha1-DoSSKXUfK59qCRn46B4SKehLqQE="
     },
     "for-each": {
       "version": "0.3.2",
@@ -1310,9 +1310,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.6.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-          "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+          "version": "6.6.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
+          "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -1813,7 +1813,7 @@
     "meow": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-      "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
+      "integrity": "sha1-1IWY9vSxRy81v2MXqVlFrONH+XU=",
       "requires": {
         "camelcase-keys": "^4.0.0",
         "decamelize-keys": "^1.0.0",
@@ -1864,7 +1864,7 @@
     "minimist-options": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "integrity": "sha1-+6TIGRM54T7PTWG+sD8HAQPz2VQ=",
       "requires": {
         "arrify": "^1.0.1",
         "is-plain-obj": "^1.1.0"
@@ -1910,7 +1910,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "requires": {
         "hosted-git-info": "^2.1.4",
         "is-builtin-module": "^1.0.0",
@@ -1986,7 +1986,7 @@
     },
     "ora": {
       "version": "0.2.3",
-      "resolved": "http://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
       "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
       "requires": {
         "chalk": "^1.1.1",
@@ -2095,7 +2095,7 @@
     "path-type": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
       "requires": {
         "pify": "^3.0.0"
       },
@@ -2293,14 +2293,14 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
+      "version": "1.1.31",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
     },
     "pump": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "integrity": "sha1-tKIRaBW94vTh6mAjVOjHVWUQemQ=",
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -2342,7 +2342,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
@@ -2611,7 +2611,7 @@
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -2634,7 +2634,7 @@
     "split2": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "integrity": "sha1-GGsldbz4PoW30YRldWI47k7kJJM=",
       "requires": {
         "through2": "^2.0.2"
       }
@@ -2646,9 +2646,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
+      "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "bugsnag-build-reporter": "^1.0.1",
-    "bugsnag-sourcemaps": "^1.0.5",
+    "bugsnag-sourcemaps": "^1.0.7",
     "run-parallel-limit": "^1.0.3"
   },
   "peerDependencies": {

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -64,7 +64,7 @@ class BugsnagSourceMapUploaderPlugin {
           // only include this file if its extension is in the list of desirable ones.
           // we use the extension from the file on disk because the name in the chunk
           // can have suffixes such as: main.js?23764
-          if (!this.extensions.includes(extname(compilation.assets[source].existsAt))) {
+          if (this.extensions.indexOf(extname(compilation.assets[source].existsAt)) === -1) {
             return null
           }
 

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -18,7 +18,7 @@ class BugsnagSourceMapUploaderPlugin {
     this.appVersion = options.appVersion
     this.overwrite = options.overwrite
     this.endpoint = options.endpoint
-    this.extensions = options.extensions || [ '.js' ]
+    this.ignoredBundleExtensions = options.ignoredBundleExtensions || [ '.css' ]
     this.validate()
   }
 
@@ -61,10 +61,10 @@ class BugsnagSourceMapUploaderPlugin {
             return null
           }
 
-          // only include this file if its extension is in the list of desirable ones.
+          // only include this file if its extension is not in the ignore list
           // we use the extension from the file on disk because the name in the chunk
           // can have suffixes such as: main.js?23764
-          if (this.extensions.indexOf(extname(compilation.assets[source].existsAt)) === -1) {
+          if (this.ignoredBundleExtensions.indexOf(extname(compilation.assets[source].existsAt)) !== -1) {
             return null
           }
 

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -3,6 +3,7 @@
 const upload = require('bugsnag-sourcemaps').upload
 const resolve = require('url').resolve
 const parallel = require('run-parallel-limit')
+const extname = require('path').extname
 
 const LOG_PREFIX = `[BugsnagSourceMapUploaderPlugin]`
 const PUBLIC_PATH_ERR =
@@ -17,6 +18,7 @@ class BugsnagSourceMapUploaderPlugin {
     this.appVersion = options.appVersion
     this.overwrite = options.overwrite
     this.endpoint = options.endpoint
+    this.extensions = options.extensions || [ '.js' ]
     this.validate()
   }
 
@@ -56,6 +58,13 @@ class BugsnagSourceMapUploaderPlugin {
 
           if (!compilation.assets[map]) {
             console.debug(`${LOG_PREFIX} source map not found in compilation output "${map}"`)
+            return null
+          }
+
+          // only include this file if its extension is in the list of desirable ones.
+          // we use the extension from the file on disk because the name in the chunk
+          // can have suffixes such as: main.js?23764
+          if (!this.extensions.includes(extname(compilation.assets[source].existsAt))) {
             return null
           }
 

--- a/test/fixtures/e/webpack.config.js
+++ b/test/fixtures/e/webpack.config.js
@@ -8,7 +8,8 @@ module.exports = {
     new MiniCssExtractPlugin(),
     new BugsnagSourceMapUploaderPlugin({
       apiKey: 'YOUR_API_KEY',
-      endpoint: `http://localhost:${process.env.PORT}`
+      endpoint: `http://localhost:${process.env.PORT}`,
+      extensions: process.env.EXTENSIONS ? process.env.EXTENSIONS.split(',') : undefined
     })
   ],
   output: {

--- a/test/fixtures/e/webpack.config.js
+++ b/test/fixtures/e/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = {
     new BugsnagSourceMapUploaderPlugin({
       apiKey: 'YOUR_API_KEY',
       endpoint: `http://localhost:${process.env.PORT}`,
-      extensions: process.env.EXTENSIONS ? process.env.EXTENSIONS.split(',') : undefined
+      ignoredBundleExtensions: process.env.IGNORED_EXTENSIONS ? process.env.IGNORED_EXTENSIONS.split(',') : undefined
     })
   ],
   output: {

--- a/test/source-map-uploader-plugin.test.js
+++ b/test/source-map-uploader-plugin.test.js
@@ -206,7 +206,7 @@ if (process.env.WEBPACK_VERSION !== '3') {
     })
     server.listen()
     exec(`${__dirname}/../node_modules/.bin/webpack`, {
-      env: Object.assign({}, process.env, { PORT: server.address().port, EXTENSIONS: '.js,.css' }),
+      env: Object.assign({}, process.env, { PORT: server.address().port, IGNORED_EXTENSIONS: '.php,.exe' }),
       cwd: `${__dirname}/fixtures/e`
     }, (err) => {
       if (err) end(err)

--- a/test/source-map-uploader-plugin.test.js
+++ b/test/source-map-uploader-plugin.test.js
@@ -120,8 +120,8 @@ test('it sends upon successful build (example project #2)', t => {
 })
 
 if (process.env.WEBPACK_VERSION !== '3') {
-  test('it works when plugins cause a chunk to have multiple source maps', t => {
-    t.plan(7)
+  test('it ignores source maps for css files by default', t => {
+    t.plan(3)
     const requests = []
     const end = err => {
       clearTimeout(timeout)
@@ -134,12 +134,55 @@ if (process.env.WEBPACK_VERSION !== '3') {
     const timeout = setTimeout(end, 10000)
 
     const done = () => {
-      t.equal(requests.length, 2)
+      t.equal(requests[0].minifiedUrl, '*/dist/main.js')
+      t.equal(requests[0].parts[0].filename, 'main.js.map')
+      t.equal(requests[0].parts[1].filename, 'main.js')
+      end()
+    }
+
+    const server = http.createServer((req, res) => {
+      parseFormdata(req, function (err, data) {
+        if (err) {
+          res.end('ERR')
+          return end(err)
+        }
+        requests.push({
+          apiKey: data.fields.apiKey,
+          minifiedUrl: data.fields.minifiedUrl,
+          parts: data.parts.map(p => ({ name: p.name, filename: p.filename }))
+        })
+        res.end('OK')
+        done()
+      })
+    })
+    server.listen()
+    exec(`${__dirname}/../node_modules/.bin/webpack`, {
+      env: Object.assign({}, process.env, { PORT: server.address().port }),
+      cwd: `${__dirname}/fixtures/e`
+    }, (err) => {
+      if (err) end(err)
+    })
+  })
+
+  test('it uploads css map files if you really want', t => {
+    t.plan(6)
+    const requests = []
+    const end = err => {
+      clearTimeout(timeout)
+      server.close()
+      if (err) return t.fail(err.message)
+      t.end()
+    }
+
+    // prevent test hanging forever
+    const timeout = setTimeout(end, 10000)
+
+    const done = () => {
       requests.sort((a, b) => a.minifiedUrl < b.minifiedUrl ? -1 : 1)
       t.equal(requests[0].minifiedUrl, '*/dist/main.css')
-      t.equal(requests[1].minifiedUrl, '*/dist/main.js')
       t.equal(requests[0].parts[0].filename, 'main.css.map')
       t.equal(requests[0].parts[1].filename, 'main.css')
+      t.equal(requests[1].minifiedUrl, '*/dist/main.js')
       t.equal(requests[1].parts[0].filename, 'main.js.map')
       t.equal(requests[1].parts[1].filename, 'main.js')
       end()
@@ -157,12 +200,13 @@ if (process.env.WEBPACK_VERSION !== '3') {
           parts: data.parts.map(p => ({ name: p.name, filename: p.filename }))
         })
         res.end('OK')
-        if (requests.length === 2) done()
+        if (requests.length < 2) return
+        done()
       })
     })
     server.listen()
     exec(`${__dirname}/../node_modules/.bin/webpack`, {
-      env: Object.assign({}, process.env, { PORT: server.address().port }),
+      env: Object.assign({}, process.env, { PORT: server.address().port, EXTENSIONS: '.js,.css' }),
       cwd: `${__dirname}/fixtures/e`
     }, (err) => {
       if (err) end(err)


### PR DESCRIPTION
CSS files (and maps for them) were being uploaded for no good reason. This feature adds a whitelist of bundle file extensions to upload source maps for. It is unlikely that anyone will ever need anything but ".js" but the option is there just in case.