### PR TITLE
feat: Improve source file lookup

### DIFF
--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -42,7 +42,7 @@ class BugsnagSourceMapUploaderPlugin {
 
         return maps.map(map => {
           // for each *.map file, find a corresponding source file in the chunk
-          const source = chunk.files.find(file => file === map.replace('.map', ''))
+          const source = chunk.files.find(file => map.replace('.map', '').endsWith(file))
 
           if (!source) {
             console.warn(`${LOG_PREFIX} no corresponding source found for "${map}" in chunk "${chunk.id}"`)

--- a/test/fixtures/f/.gitignore
+++ b/test/fixtures/f/.gitignore
@@ -1,0 +1,2 @@
+dist
+tmp

--- a/test/fixtures/f/src/index.js
+++ b/test/fixtures/f/src/index.js
@@ -1,0 +1,1 @@
+console.log('hi')

--- a/test/fixtures/f/webpack.config.js
+++ b/test/fixtures/f/webpack.config.js
@@ -1,0 +1,20 @@
+const BugsnagSourceMapUploaderPlugin = require('../../../').BugsnagSourceMapUploaderPlugin
+const webpack = require('webpack')
+
+module.exports = {
+  entry: './src/index.js',
+  devtool: false,
+  plugins: [
+    new webpack.SourceMapDevToolPlugin({
+      filename: '../tmp/[file].map'
+    }),
+    new BugsnagSourceMapUploaderPlugin({
+      apiKey: 'YOUR_API_KEY',
+      endpoint: `http://localhost:${process.env.PORT}`
+    })
+  ],
+  output: {
+    publicPath: '*/dist'
+  },
+  mode: 'development',
+};

--- a/test/source-map-uploader-plugin.test.js
+++ b/test/source-map-uploader-plugin.test.js
@@ -119,6 +119,54 @@ test('it sends upon successful build (example project #2)', t => {
   })
 })
 
+test('it’s able to locate the files when source maps are written to a different directory', t => {
+  const end = err => {
+    server.close()
+    if (err) return t.fail(err.message)
+    t.end()
+  }
+
+  t.plan(7)
+  const server = http.createServer((req, res) => {
+    parseFormdata(req, function (err, data) {
+      if (err) {
+        res.end('ERR')
+        return end(err)
+      }
+      t.equal(data.fields.apiKey, 'YOUR_API_KEY', 'body should contain api key')
+      t.equal(data.fields.minifiedUrl, '*/dist/main.js', 'body should contain minified url')
+      t.equal(data.parts.length, 2, 'body should contain 2 uploads')
+      let partsRead = 0
+      data.parts.forEach(part => {
+        part.stream.pipe(concat(data => {
+          partsRead++
+          if (part.name === 'sourceMap') {
+            t.equal(part.mimetype, 'application/json')
+            try {
+              t.ok(JSON.parse(data), 'sourceMap should be valid json')
+            } catch (e) {
+              end(e)
+            }
+          }
+          if (part.name === 'minifiedFile') {
+            t.equal(part.mimetype, 'application/javascript')
+            t.ok(data.length, 'js bundle should have length')
+          }
+          if (partsRead === 2) end()
+        }))
+      })
+      res.end('OK')
+    })
+  })
+  server.listen()
+  exec(`${__dirname}/../node_modules/.bin/webpack`, {
+    env: Object.assign({}, process.env, { PORT: server.address().port }),
+    cwd: `${__dirname}/fixtures/f`
+  }, err => {
+    if (err) end(err)
+  })
+})
+
 if (process.env.WEBPACK_VERSION !== '3') {
   test('it works when plugins cause a chunk to have multiple source maps', t => {
     t.plan(7)


### PR DESCRIPTION
It's possible to configure the source map plugin to put source maps in a different directory than the output bundles. This change allows the source of the bundle to be found based on matching file names (per chunk) rather than by entire matching path.

Fixes #20.