### PR TITLE
Support Webpack output.futureEmitAssets option

### DIFF
--- a/test/fixtures/g/.gitignore
+++ b/test/fixtures/g/.gitignore
@@ -1,0 +1,2 @@
+bundle.js
+bundle.js.map

--- a/test/fixtures/g/app.js
+++ b/test/fixtures/g/app.js
@@ -1,0 +1,1 @@
+console.log('hello world')

--- a/test/fixtures/g/webpack.config.js
+++ b/test/fixtures/g/webpack.config.js
@@ -1,0 +1,18 @@
+const BugsnagSourceMapUploaderPlugin = require('../../../').BugsnagSourceMapUploaderPlugin
+
+module.exports = {
+  entry: './app.js',
+  devtool: 'hidden-source-map',
+  output: {
+    path: __dirname,
+    filename: './bundle.js',
+    publicPath: 'https://foobar.com/js',
+    futureEmitAssets: true
+  },
+  plugins: [
+    new BugsnagSourceMapUploaderPlugin({
+      apiKey: 'YOUR_API_KEY',
+      endpoint: `http://localhost:${process.env.PORT}`
+    })
+  ]
+}


### PR DESCRIPTION
This option is going to become the default in Webpack v5.

This PR adds a failing test for the current implementation and subsequently provides a fix.

Previously we relied on "existsAt" which is removed from Webpack 4.29.x (when
output.futureEmitAssets is enabled) and will be gone in 5.x by default. Calculates the paths using
apis that exist from Webpack 3 through to 5.

Fixes #28