### PR TITLE
fix: Work around url.resolve() bug with asterisk (*) character

### DIFF
--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const upload = require('bugsnag-sourcemaps').upload
-const resolve = require('url').resolve
 const parallel = require('run-parallel-limit')
 const extname = require('path').extname
 
@@ -74,14 +73,11 @@ class BugsnagSourceMapUploaderPlugin {
           return {
             source: outputChunkLocation,
             map: outputSourceMapLocation,
-            url: resolve(
+            url: '' +
               // ensure publicPath has a trailing slash
-              publicPath.replace(/[^/]$/, '$&/'),
-              // ensure source doesn't have a leading slash (sometimes it does, e.g.
-              // in laravel-mix, but this throws off the url resolve() call) see issue
-              // for more detail: https://github.com/bugsnag/webpack-bugsnag-plugins/issues/11
-              source.replace(/^\//, '')
-            ).toString()
+              publicPath.replace(/[^/]$/, '$&/') +
+              // remove leading / or ./ from source
+              source.replace(/^\.?\//, '')
           }
         }).filter(Boolean)
       }


### PR DESCRIPTION
Our API uses an asterisk as a wildcard, but having one in a url confuses the `url.resolve(base, href)` method and `new URL(href, base)` doesn't like it at all in certain positions.

#### `url.resolve()` doesn't like `*` after `/`

```
> url.resolve('http://*.mydomain.xyz/', 'assets/js/bundle.js')
'http:///*.mydomain.xyz/assets/js/bundle.js'
```
_Notice the extra `/` 👆_

#### `new URL()` doesn't like `*` as part of the protocol

```
> new URL('assets/js/bundle', 'http*://mydomain.xyz/')
Thrown:
TypeError [ERR_INVALID_URL]: Invalid URL: http*://mydomain.xyz/
```

Since it seems like a bad idea to parse the URL if it has a * wildcard in it, I figured did it really make sense to do so? All we were really using for was to join the partial url with the local path to the static asset, so I've removed the parsing logic and replaced it with simple concatenation. All that was needed is to manually strip the `./` preceding the local path.

This fixes #35.