### PR TITLE
fix: Allow publicPath to be empty string

### DIFF
--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -5,6 +5,12 @@ const parallel = require('run-parallel-limit')
 const extname = require('path').extname
 
 const LOG_PREFIX = `[BugsnagSourceMapUploaderPlugin]`
+const PUBLIC_PATH_WARN =
+  '`publicPath` is not set.\n\n' +
+  '  Source maps must be uploaded with the pattern that matches the file path in stacktraces.\n\n' +
+  '  To make this message go away, set "publicPath" in Webpack config ("output" section)\n' +
+  '  or set "publicPath" in BugsnagSourceMapUploaderPlugin constructor.\n\n' +
+  '  In some cases, such as in a Node environment, it is safe to ignore this message.\n'
 
 class BugsnagSourceMapUploaderPlugin {
   constructor (options) {
@@ -33,6 +39,10 @@ class BugsnagSourceMapUploaderPlugin {
       const chunkToSourceMapDescriptors = chunk => {
         // find .map files in this chunk
         const maps = chunk.files.filter(file => /.+\.map(\?.*)?$/.test(file))
+
+        if (!publicPath) {
+          console.warn(`${LOG_PREFIX} ${PUBLIC_PATH_WARN}`)
+        }
 
         return maps.map(map => {
           // for each *.map file, find a corresponding source file in the chunk

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -5,10 +5,6 @@ const parallel = require('run-parallel-limit')
 const extname = require('path').extname
 
 const LOG_PREFIX = `[BugsnagSourceMapUploaderPlugin]`
-const PUBLIC_PATH_ERR =
-  'Cannot determine "minifiedUrl" argument for bugsnag-sourcemaps. ' +
-  'Please set "publicPath" in Webpack config ("output" section) ' +
-  'or set "publicPath" in BugsnagSourceMapUploaderPlugin constructor.'
 
 class BugsnagSourceMapUploaderPlugin {
   constructor (options) {
@@ -31,13 +27,8 @@ class BugsnagSourceMapUploaderPlugin {
     const plugin = (compilation, cb) => {
       const compiler = compilation.compiler
       const stats = compilation.getStats().toJson()
-      const publicPath = this.publicPath || stats.publicPath
+      const publicPath = this.publicPath || stats.publicPath || ''
       const outputPath = compilation.getPath(compiler.outputPath)
-
-      if (!publicPath) {
-        console.warn(`${LOG_PREFIX} ${PUBLIC_PATH_ERR}`)
-        return cb()
-      }
 
       const chunkToSourceMapDescriptors = chunk => {
         // find .map files in this chunk


### PR DESCRIPTION
This supports the use case of targeting `node` with webpack, using the top level project directory as the target for the bundled js.

~Caveat: as you can see from the removed code, the library tried to be helpful as most users would want to set the `publicPath` either directly or via Webpack's `output`. This message is now not printed. It's hard to know how many people this helped.~

Update: the `publicPath` warning is now reinstated, but the build continues and the upload is attempted.