### PR TITLE
Add codeBundleId support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Allow setting of `codeBundleId` on `BugsnagSourceMapUploaderPlugin` (#40, fixes #38)
+
 ## 1.4.2 (2019-09-10)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Upload your application's sourcemap(s) to Bugsnag. When Webpack is done producin
   - `apiKey: string` your Bugsnag API key __[required]__
   - `publicPath: string` the path to your bundled assets (as the browser will see them). This option must either be provided here, or as [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) in your Webpack config.
   - `appVersion: string` the version of the application you are building
+  - `codeBundleId: string` the codeBundleId (e.g. for NativeScript projects)
   - `overwrite: boolean` whether you want to overwrite previously uploaded sourcemaps
   - `endpoint: string` post the build payload to a URL other than the default (`https://upload.bugsnag.com`)
   - `ignoredBundleExtensions: string[]` a list of bundle file extensions which shouldn't be uploaded (default `[ '.css' ]`)

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -104,7 +104,7 @@ class BugsnagSourceMapUploaderPlugin {
     const opts = {
       apiKey: this.apiKey,
       appVersion: this.appVersion,
-      codeBundleId" this.codeBundleId,
+      codeBundleId: this.codeBundleId,
       minifiedUrl: sm.url,
       minifiedFile: sm.source,
       sourceMap: sm.map

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -17,6 +17,7 @@ class BugsnagSourceMapUploaderPlugin {
     this.apiKey = options.apiKey
     this.publicPath = options.publicPath
     this.appVersion = options.appVersion
+    this.codeBundleId = options.codeBundleId
     this.overwrite = options.overwrite
     this.endpoint = options.endpoint
     this.ignoredBundleExtensions = options.ignoredBundleExtensions || [ '.css' ]
@@ -103,6 +104,7 @@ class BugsnagSourceMapUploaderPlugin {
     const opts = {
       apiKey: this.apiKey,
       appVersion: this.appVersion,
+      codeBundleId" this.codeBundleId,
       minifiedUrl: sm.url,
       minifiedFile: sm.source,
       sourceMap: sm.map

--- a/test/fixtures/d/webpack.config.js
+++ b/test/fixtures/d/webpack.config.js
@@ -11,7 +11,8 @@ module.exports = {
   },
   plugins: [
     new BugsnagSourceMapUploaderPlugin({
-      apiKey: 'YOUR_API_KEY',
+			apiKey: 'YOUR_API_KEY',
+			codeBundleId: '1.0.0-b12',
       endpoint: `http://localhost:${process.env.PORT}`
     })
   ]

--- a/test/fixtures/d/webpack.config.js
+++ b/test/fixtures/d/webpack.config.js
@@ -11,8 +11,8 @@ module.exports = {
   },
   plugins: [
     new BugsnagSourceMapUploaderPlugin({
-			apiKey: 'YOUR_API_KEY',
-			codeBundleId: '1.0.0-b12',
+      apiKey: 'YOUR_API_KEY',
+      codeBundleId: '1.0.0-b12',
       endpoint: `http://localhost:${process.env.PORT}`
     })
   ]

--- a/test/source-map-uploader-plugin.test.js
+++ b/test/source-map-uploader-plugin.test.js
@@ -30,7 +30,7 @@ test('it sends upon successful build (example project #1)', t => {
     t.end()
   }
 
-  t.plan(7)
+  t.plan(8)
   const server = http.createServer((req, res) => {
     parseFormdata(req, function (err, data) {
       if (err) {
@@ -38,6 +38,7 @@ test('it sends upon successful build (example project #1)', t => {
         return end(err)
       }
       t.equal(data.fields.apiKey, 'YOUR_API_KEY', 'body should contain api key')
+      t.equal(data.fields.codeBundleId, '1.0.0-b12', 'body could contain codeBundleId')
       t.ok(/^https:\/\/foobar.com\/js\/main\.js\?[\w\d]+$/.test(data.fields.minifiedUrl), 'body should contain minified url')
       t.equal(data.parts.length, 2, 'body should contain 2 uploads')
       let partsRead = 0


### PR DESCRIPTION
Allow setting of `codeBundleId` on `BugsnagSourceMapUploaderPlugin`

Fixes #38

Validated E2E in local environment.