### PR TITLE
ci: Update Node/Webpack version matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "4"
   - "6"
   - "8"
+  - "10"
+  - "12"
 
 env:
   - WEBPACK_VERSION=3
@@ -11,6 +13,8 @@ env:
 matrix:
   exclude:
   - node_js: "4"
+    env: WEBPACK_VERSION=4
+  - node_js: "6"
     env: WEBPACK_VERSION=4
 
 before_script: bin/ci-install.sh


### PR DESCRIPTION
CI started failing on the Webpack v4 / Node v6 combination due to some dependency of Webpack 4. Node v6 is long out of LTS and unsupported anyway.

This skips that combination, and adds a bunch of newer Node versions.


----

The error was a due to the `css-loader` module using the object rest/spread syntax `...` which is not supported by Node v6:

```
/Users/bengourley/Development/bugsnag-builds/webpack-bugsnag-plugins/node_modules/css-loader/dist/plugins/postcss-icss-parser.js:34
      accumulator[normalizedUrl] = { ...accumulator[normalizedUrl],
                                     ^^^

SyntaxError: Unexpected token ...
    at NativeCompileCache._moduleCompile (/Users/bengourley/Development/bugsnag-builds/webpack-bugsnag-plugins/node_modules/v8-compile-cache/v8-compile-cache.js:240:18)
    at Module._compile (/Users/bengourley/Development/bugsnag-builds/webpack-bugsnag-plugins/node_modules/v8-compile-cache/v8-compile-cache.js:186:36)
    at Object.Module._extensions..js (module.js:586:10)
    at Module.load (module.js:494:32)
    at tryModuleLoad (module.js:453:12)
    at Function.Module._load (module.js:445:3)
    at Module.require (module.js:504:17)
```