### PR TITLE
docs: Default behavior of `appVersion` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Upload your application's sourcemap(s) to Bugsnag. When Webpack is done producin
 - `opts` provide options to the sourcemap uploader
   - `apiKey: string` your Bugsnag API key __[required]__
   - `publicPath: string` the path to your bundled assets (as the browser will see them). This option must either be provided here, or as [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) in your Webpack config.
-  - `appVersion: string` the version of the application you are building (defaults to the `version` set in your project's package.json file, if specified)
+  - `appVersion: string` the version of the application you are building (defaults to the `version` set in your project's package.json file, if specified there)
   - `codeBundleId: string` the codeBundleId (e.g. for NativeScript projects)
   - `overwrite: boolean` whether you want to overwrite previously uploaded sourcemaps
   - `endpoint: string` post the build payload to a URL other than the default (`https://upload.bugsnag.com`)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Upload your application's sourcemap(s) to Bugsnag. When Webpack is done producin
 - `opts` provide options to the sourcemap uploader
   - `apiKey: string` your Bugsnag API key __[required]__
   - `publicPath: string` the path to your bundled assets (as the browser will see them). This option must either be provided here, or as [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) in your Webpack config.
-  - `appVersion: string` the version of the application you are building (defaults to the `version` set in your project's package.json file, if specified there)
+  - `appVersion: string` the version of the application you are building (defaults to the `version` set in your project's package.json file, if one is specified there)
   - `codeBundleId: string` the codeBundleId (e.g. for NativeScript projects)
   - `overwrite: boolean` whether you want to overwrite previously uploaded sourcemaps
   - `endpoint: string` post the build payload to a URL other than the default (`https://upload.bugsnag.com`)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Upload your application's sourcemap(s) to Bugsnag. When Webpack is done producin
 - `opts` provide options to the sourcemap uploader
   - `apiKey: string` your Bugsnag API key __[required]__
   - `publicPath: string` the path to your bundled assets (as the browser will see them). This option must either be provided here, or as [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) in your Webpack config.
-  - `appVersion: string` the version of the application you are building
+  - `appVersion: string` the version of the application you are building (defaults to the `version` set in your project's package.json file, if specified)
   - `codeBundleId: string` the codeBundleId (e.g. for NativeScript projects)
   - `overwrite: boolean` whether you want to overwrite previously uploaded sourcemaps
   - `endpoint: string` post the build payload to a URL other than the default (`https://upload.bugsnag.com`)


### PR DESCRIPTION
This documents the fact that when `appVersion` is not specified in options passed to `BugsnagSourceMapUploaderPlugin`, an attempt will be made to automatically infer it based on the consuming project's package.json (which happens in https://github.com/bugsnag/bugsnag-sourcemaps/blob/master/lib/get-app-version.js#L13).

I think that documenting this is worthwhile because it may be unexpected behavior for those familiar with configuring notifiers. At least in the case of [@bugsnag/js](https://github.com/bugsnag/bugsnag-js/tree/next/packages/js), failure to specify `appVersion` leaves app version tracked as "unknown", which is fine in the case where no version is set in package.json, but in the case where a version *is* set, causes a mismatch and Bugsnag won't associate the versioned sourcemaps to the unversioned error notifications.

Users who leave `appVersion` unset might be expecting sourcemaps to get uploaded against version `unknown`, matching their notifier's default behavior; currently this can only be accomplished by unsetting "version" in package.json OR by switching to use appVersion, and specifying it to both the notifier and sourcemap uploader.