### PR TITLE
Webpack 5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ node_js:
 env:
   - WEBPACK_VERSION=3
   - WEBPACK_VERSION=4
+  - WEBPACK_VERSION=5
 
 matrix:
   exclude:
@@ -16,5 +17,9 @@ matrix:
     env: WEBPACK_VERSION=4
   - node_js: "6"
     env: WEBPACK_VERSION=4
+  - node_js: "4"
+    env: WEBPACK_VERSION=5
+  - node_js: "6"
+    env: WEBPACK_VERSION=5
 
 before_script: bin/ci-install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,7 @@ matrix:
     env: WEBPACK_VERSION=5
   - node_js: "6"
     env: WEBPACK_VERSION=5
+  - node_js: "8"
+    env: WEBPACK_VERSION=5
 
 before_script: bin/ci-install.sh

--- a/bin/ci-install.sh
+++ b/bin/ci-install.sh
@@ -1,5 +1,5 @@
 if [ "$WEBPACK_VERSION" -eq "3" ]; then
   npm i --no-save --no-package-lock webpack@3
 else
-  npm i --no-save --no-package-lock webpack@$WEBPACK_VERSION webpack-cli mini-css-extract-plugin css-loader
+  npm i --no-save --no-package-lock webpack@$WEBPACK_VERSION webpack-cli@$WEBPACK_VERSION mini-css-extract-plugin css-loader
 fi

--- a/bin/ci-install.sh
+++ b/bin/ci-install.sh
@@ -1,5 +1,7 @@
 if [ "$WEBPACK_VERSION" -eq "3" ]; then
   npm i --no-save --no-package-lock webpack@3
+elif [ "$WEBPACK_VERSION" -eq "4" ]; then
+  npm i --no-save --no-package-lock webpack@$WEBPACK_VERSION webpack-cli@3 mini-css-extract-plugin css-loader
 else
-  npm i --no-save --no-package-lock webpack@$WEBPACK_VERSION webpack-cli@$WEBPACK_VERSION mini-css-extract-plugin css-loader
+  npm i --no-save --no-package-lock webpack@$WEBPACK_VERSION webpack-cli mini-css-extract-plugin css-loader
 fi

--- a/bin/ci-install.sh
+++ b/bin/ci-install.sh
@@ -1,5 +1,5 @@
 if [ "$WEBPACK_VERSION" -eq "3" ]; then
   npm i --no-save --no-package-lock webpack@3
 else
-  npm i --no-save --no-package-lock webpack@4 webpack-cli mini-css-extract-plugin css-loader
+  npm i --no-save --no-package-lock webpack@$WEBPACK_VERSION webpack-cli mini-css-extract-plugin css-loader
 fi

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -4,6 +4,7 @@ const upload = require('bugsnag-sourcemaps').upload
 const parallel = require('run-parallel-limit')
 const extname = require('path').extname
 const join = require('path').join
+const webpackVersion = require('webpack').version
 
 const LOG_PREFIX = `[BugsnagSourceMapUploaderPlugin]`
 const PUBLIC_PATH_WARN =
@@ -32,6 +33,9 @@ class BugsnagSourceMapUploaderPlugin {
   }
 
   apply (compiler) {
+    // considering this is used to check for a version >= 5, it's fine to default to 0.0.0 in case it's not set
+    const webpackMajorVersion = parseInt((webpackVersion || '0.0.0').split('.')[0], 10)
+
     const plugin = (compilation, cb) => {
       const compiler = compilation.compiler
       const stats = compilation.getStats().toJson()
@@ -40,7 +44,7 @@ class BugsnagSourceMapUploaderPlugin {
 
       const chunkToSourceMapDescriptors = chunk => {
         // find .map files in this chunk
-        const maps = chunk.files.filter(file => /.+\.map(\?.*)?$/.test(file))
+        const maps = chunk[webpackMajorVersion >= 5 ? 'auxiliaryFiles' : 'files'].filter(file => /.+\.map(\?.*)?$/.test(file))
 
         if (!publicPath) {
           console.warn(`${LOG_PREFIX} ${PUBLIC_PATH_WARN}`)

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -3,6 +3,7 @@
 const upload = require('bugsnag-sourcemaps').upload
 const parallel = require('run-parallel-limit')
 const extname = require('path').extname
+const join = require('path').join
 
 const LOG_PREFIX = `[BugsnagSourceMapUploaderPlugin]`
 const PUBLIC_PATH_WARN =
@@ -64,8 +65,8 @@ class BugsnagSourceMapUploaderPlugin {
             return null
           }
 
-          const outputChunkLocation = stripQuery(compiler.outputFileSystem.join(outputPath, source))
-          const outputSourceMapLocation = stripQuery(compiler.outputFileSystem.join(outputPath, map))
+          const outputChunkLocation = stripQuery(join(outputPath, source))
+          const outputSourceMapLocation = stripQuery(join(outputPath, map))
 
           // only include this file if its extension is not in the ignore list
           if (this.ignoredBundleExtensions.indexOf(extname(outputChunkLocation)) !== -1) {

--- a/test/fixtures/g/webpack.config.js
+++ b/test/fixtures/g/webpack.config.js
@@ -3,12 +3,16 @@ const BugsnagSourceMapUploaderPlugin = require('../../../').BugsnagSourceMapUplo
 module.exports = {
   entry: './app.js',
   devtool: 'hidden-source-map',
-  output: {
-    path: __dirname,
-    filename: './bundle.js',
-    publicPath: 'https://foobar.com/js',
-    futureEmitAssets: true
-  },
+  output: Object.assign(
+    {
+      path: __dirname,
+      filename: './bundle.js',
+      publicPath: 'https://foobar.com/js',
+    },
+    // As per webpack documentation:
+    // "output.futureEmitAssets option will be removed in webpack v5.0.0 and this behaviour will become the new default."
+    // so it can safely be omitted for webpack>=5 while still getting a similar result
+    parseInt(process.env.WEBPACK_VERSION, 10) < 5 ? { futureEmitAssets: true } : {}),
   plugins: [
     new BugsnagSourceMapUploaderPlugin({
       apiKey: 'YOUR_API_KEY',


### PR DESCRIPTION
## Goal

The plugin is not working with Webpack 5

## Design

The API for plugins changed a little, and it breaks the current implementation

## Changeset

* `chunk.files` not longer holds maps, instead maps are listed in `chunks.auxiliaryFiles`
* `compiler.outputFileSystem` is getting reworked to be closer to the actual Node FS, meaning `join` is deprecated / doomed to disappear as it's not standard. See: https://github.com/webpack/memory-fs/issues/67 https://github.com/webpack/webpack-dev-middleware/pull/370

## Testing

* Manually tested by running webpack locally and checking that with these changes source maps are getting sent to Bugsnag
* Updated tests files so the test suite also runs against webpack 5