### PR TITLE
specify webpack peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ module.exports = {
 }
 ```
 
+## Supported Webpack versions
+
+These plugins have been tested with webpack versions 3, 4 and 5.
+
 ## Support
 
 - [Search open and closed issues](https://github.com/bugsnag/webpack-bugsnag-plugins/issues?q=is%3Aissue) issues for similar problems

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "run-parallel-limit": "^1.0.6"
   },
   "peerDependencies": {
-    "webpack": ">=3"
+    "webpack": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
## Goal

To provide feedback to users when these plugins are used with versions of webpack that haven't been tested.

## Design

peer dependencies is a standard mechanism for handling this situation

## Changeset

Updated peer dependencies to exclude all but webpack major versions 3, 4 and 5.

## Testing

- [ ] Review CI test output, ensure no peer dependency warnings