### PR TITLE
use webpack for logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## TBD
 
 - Update to v2 of @bugsnag/source-maps (#53)
+- Use webpack for logging (#55)
 
 ## 1.6.0 (2020-12-17)
 

--- a/build-reporter-plugin.js
+++ b/build-reporter-plugin.js
@@ -12,7 +12,13 @@ class BugsnagBuildReporterPlugin {
     const plugin = (compilation, cb) => {
       const stats = compilation.getStats()
       if (stats.hasErrors()) return cb(null)
-      reportBuild(this.build, this.options)
+      const options = Object.assign(this.options,
+        !this.options.logger && compiler.getInfrastructureLogger
+          ? { logger: compiler.getInfrastructureLogger('BugsnagBuildReporterPlugin') }
+          : {}
+      )
+
+      reportBuild(this.build, options)
         .then(() => cb(null))
         .catch((/* err */) => {
           // ignore err: a failure to notify Bugsnag shouldn't fail the build

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -93,7 +93,7 @@ class BugsnagSourceMapUploaderPlugin {
 
       const sourceMaps = stats.chunks.map(chunkToSourceMapDescriptors).reduce((accum, ds) => accum.concat(ds), [])
       parallel(sourceMaps.map(sm => cb => {
-        logger.log(`${logPrefix}uploading sourcemap for "${sm.url}"`)
+        logger.info(`${logPrefix}uploading sourcemap for "${sm.url}"`)
         browser.uploadOne(this.getUploadOpts(sm)).then(cb, cb)
       }), 10, cb)
     }

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -41,13 +41,15 @@ class BugsnagSourceMapUploaderPlugin {
       const stats = compilation.getStats().toJson()
       const publicPath = this.publicPath || stats.publicPath || ''
       const outputPath = compilation.getPath(compiler.outputPath)
+      const logger = compiler.getInfrastructureLogger ? compiler.getInfrastructureLogger('BugsnagSourceMapUploaderPlugin') : console
+      const logPrefix = compiler.getInfrastructureLogger ? '' : `${LOG_PREFIX} `
 
       const chunkToSourceMapDescriptors = chunk => {
         // find .map files in this chunk
         const maps = chunk[webpackMajorVersion >= 5 ? 'auxiliaryFiles' : 'files'].filter(file => /.+\.map(\?.*)?$/.test(file))
 
         if (!publicPath) {
-          console.warn(`${LOG_PREFIX} ${PUBLIC_PATH_WARN}`)
+          logger.warn(`${logPrefix}${PUBLIC_PATH_WARN}`)
         }
 
         return maps.map(map => {
@@ -55,17 +57,17 @@ class BugsnagSourceMapUploaderPlugin {
           const source = chunk.files.find(file => map.replace('.map', '').endsWith(file))
 
           if (!source) {
-            console.warn(`${LOG_PREFIX} no corresponding source found for "${map}" in chunk "${chunk.id}"`)
+            logger.warn(`${logPrefix}no corresponding source found for "${map}" in chunk "${chunk.id}"`)
             return null
           }
 
           if (!compilation.assets[source]) {
-            console.debug(`${LOG_PREFIX} source asset not found in compilation output "${source}"`)
+            logger.debug(`${logPrefix}source asset not found in compilation output "${source}"`)
             return null
           }
 
           if (!compilation.assets[map]) {
-            console.debug(`${LOG_PREFIX} source map not found in compilation output "${map}"`)
+            logger.debug(`${logPrefix}source map not found in compilation output "${map}"`)
             return null
           }
 
@@ -91,7 +93,7 @@ class BugsnagSourceMapUploaderPlugin {
 
       const sourceMaps = stats.chunks.map(chunkToSourceMapDescriptors).reduce((accum, ds) => accum.concat(ds), [])
       parallel(sourceMaps.map(sm => cb => {
-        console.log(`${LOG_PREFIX} uploading sourcemap for "${sm.url}"`)
+        logger.log(`${logPrefix}uploading sourcemap for "${sm.url}"`)
         browser.uploadOne(this.getUploadOpts(sm)).then(cb, cb)
       }), 10, cb)
     }


### PR DESCRIPTION
use the webpack infrastructure logger (if available) rather than outputting to the console directly so that webpack `--silent` mode is respected.

## Goal

- Webpack supports a `--silent` option and our webpack plugins should respect that
- In webpack 4 it is common to output stats as json and pipe it to a file (e.g. `webpack --mode=production --profile --json > stats/stats.json`). This requires silent mode to be respected. Note: webpack 5 stats don't need piping as they are generated with`npx webpack --profile --json=compilation-stats.json`. See https://webpack.js.org/api/stats/

## Design

Use the webpack recommended way of handling logging in webpack 4 and 5 plugins. See https://v4.webpack.js.org/api/plugins/#logging and https://webpack.js.org/api/plugins/#logging

The logger returned with `getLogger` doesn't output anything to the console in the event of an error, so `getInfrastructureLogger` is used, as the output is more useful.

`BugsnagBuildReporterPlugin` will not use the webpack logger when a custom logger option is supplied.

webpack <= 4.37 doesn't have the logging API so:
- `BugsnagBuildReporterPlugin` falls back to its built in logger (unless a custom option logger is supplied);  and
- `BugsnagSourceMapUploaderPlugin` falls back to `console` (there is no custom logger option).

## Changeset

- BugsnagBuildReporterPlugin: use the webpack "infrastructure" logger for logging, if present
- BugsnagSourceMapUploaderPlugin: use the webpack "infrastructure logger" for logging, if present

## Testing

- e2e tests use webpack 3/4/5 are passing
-  the workaround in dashboard-js can be removed (see https://github.com/bugsnag/dashboard-js/pull/4231)
- manually checked output of errors and log level bugs against dashboard-js

Output from webpack 4:

**Before**

```
[bugsnag-build-reporter] Configuration error
[bugsnag-build-reporter]   sourceControl must be an object containing { provider, repository, revision } (got "{
  provider: 'github',
  repository: 'https://github.com/bugsnag/dashboard-js',
  revision: undefined
}")
[BugsnagSourceMapUploaderPlugin] uploading sourcemap for "http://localhost:8080/assets/app.826c2f1ffce9f1548c4c.js"
Error: HTTP status 401 received from upload API
    at /Users/dan/dashboard-js/node_modules/@bugsnag/source-maps/dist/Request.js:105:33
    at ConcatStream.<anonymous> (/Users/dan/dashboard-js/node_modules/@bugsnag/source-maps/node_modules/concat-stream/index.js:37:43)
    at ConcatStream.emit (node:events:381:22)
    at finishMaybe (/Users/dan/dashboard-js/node_modules/@bugsnag/source-maps/node_modules/readable-stream/lib/_stream_writable.js:620:14)
    at afterWrite (/Users/dan/dashboard-js/node_modules/@bugsnag/source-maps/node_modules/readable-stream/lib/_stream_writable.js:466:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
error Command failed with exit code 1.
```

**After:**

```
<e> [BugsnagBuildReporterPlugin] Configuration error
<e> [BugsnagBuildReporterPlugin]   sourceControl must be an object containing { provider, repository, revision } (got "{
<e>   provider: 'github',
<e>   repository: 'https://github.com/bugsnag/dashboard-js',
<e>   revision: undefined
<e> }")
Error: HTTP status 401 received from upload API
    at /Users/dan/dashboard-js/node_modules/@bugsnag/source-maps/dist/Request.js:105:33
    at ConcatStream.<anonymous> (/Users/dan/dashboard-js/node_modules/@bugsnag/source-maps/node_modules/concat-stream/index.js:37:43)
    at ConcatStream.emit (node:events:381:22)
    at finishMaybe (/Users/dan/dashboard-js/node_modules/@bugsnag/source-maps/node_modules/readable-stream/lib/_stream_writable.js:620:14)
    at afterWrite (/Users/dan/dashboard-js/node_modules/@bugsnag/source-maps/node_modules/readable-stream/lib/_stream_writable.js:466:3)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
error Command failed with exit code 1.
```

Note the absence of `[BugsnagSourceMapUploaderPlugin] uploading sourcemap for "http://localhost:8080/assets/app.826c2f1ffce9f1548c4c.js"` as the webpack logger does not output log level.

If it was a warn it would output `<w> [BugsnagSourceMapUploaderPlugin] uploading sourcemap for "http://localhost:8080/assets/app.826c2f1ffce9f1548c4c.js"` (in yellow colour).

It might be worth reviewing the various levels used throughout the code.

In terms of unit-level coverage I think the first step would be to convert to jest
