### PR TITLE
fix: :bug: fix encoding characters in source map paths

### DIFF
--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -80,7 +80,7 @@ class BugsnagSourceMapUploaderPlugin {
           }
 
           // encode any special characters in the source path
-          escapedSource = source.split('/').map((s) => encodeURIComponent(s)).join('/')
+          const escapedSource = source.split('/').map((s) => encodeURIComponent(s)).join('/')
 
           return {
             source: outputChunkLocation,

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -79,15 +79,17 @@ class BugsnagSourceMapUploaderPlugin {
             return null
           }
 
+          // encode any special characters in the source path
+          escapedSource = source.split('/').map((s) => encodeURIComponent(s)).join('/')
+
           return {
             source: outputChunkLocation,
             map: outputSourceMapLocation,
-            url: encodeURIComponent('' +
+            url: '' +
               // ensure publicPath has a trailing slash
               publicPath.replace(/[^/]$/, '$&/') +
               // remove leading / or ./ from source
-              source.replace(/^\.?\//, '')
-            )
+              escapedSource.replace(/^\.?\//, '')
           }
         }).filter(Boolean)
       }

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -80,7 +80,8 @@ class BugsnagSourceMapUploaderPlugin {
           }
 
           // encode any special characters in the source path
-          const escapedSource = source.split('/').map((s) => encodeURIComponent(s)).join('/')
+          // this helps to match the reported source path in the stacktrace
+          const escapedSource = source.replace(/%40/g, '@').replace(/%5B/g, '[').replace(/%5D/g, ']')
 
           return {
             source: outputChunkLocation,

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -81,7 +81,7 @@ class BugsnagSourceMapUploaderPlugin {
 
           // encode any special characters in the source path
           // this helps to match the reported source path in the stacktrace
-          const escapedSource = source.replace(/%40/g, '@').replace(/%5B/g, '[').replace(/%5D/g, ']')
+          const escapedSource = source.replace(/@/g, '%40').replace(/\[/g, '%5B').replace(/\]/g, '%5D')
 
           return {
             source: outputChunkLocation,

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -82,7 +82,7 @@ class BugsnagSourceMapUploaderPlugin {
           return {
             source: outputChunkLocation,
             map: outputSourceMapLocation,
-            url: encodeURI('' +
+            url: encodeURIComponent('' +
               // ensure publicPath has a trailing slash
               publicPath.replace(/[^/]$/, '$&/') +
               // remove leading / or ./ from source

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -82,11 +82,12 @@ class BugsnagSourceMapUploaderPlugin {
           return {
             source: outputChunkLocation,
             map: outputSourceMapLocation,
-            url: '' +
+            url: encodeURI('' +
               // ensure publicPath has a trailing slash
               publicPath.replace(/[^/]$/, '$&/') +
               // remove leading / or ./ from source
               source.replace(/^\.?\//, '')
+            )
           }
         }).filter(Boolean)
       }


### PR DESCRIPTION
fixes #51

## Goal

Source Maps uploaded to BugSnag are not URI encoded, but source maps reported by the browser are. This fix ensures that if there are characters encoded by the browser that the source maps match.

## Changeset

Added a call to `encodeURI` as suggested in the bug report.

## Testing

run `npm test`