### PR TITLE
add support for projectRoot in source-map-uploader-plugin

### DIFF
--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -23,6 +23,7 @@ class BugsnagSourceMapUploaderPlugin {
     this.overwrite = options.overwrite
     this.endpoint = options.endpoint
     this.ignoredBundleExtensions = options.ignoredBundleExtensions || ['.css']
+    this.projectRoot = options.projectRoot;
     this.validate()
   }
 
@@ -118,6 +119,7 @@ class BugsnagSourceMapUploaderPlugin {
     }
     if (this.endpoint) opts.endpoint = this.endpoint
     if (this.overwrite) opts.overwrite = this.overwrite
+    if (this.projectRoot) opts.projectRoot = this.projectRoot;
     return opts
   }
 }


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
`@bugsnag/source-maps` provides an option for `projectRoot`, but `BugsnagSourceMapUploaderPlugin` does not expose that option. This helps for situations where the project being built is in a subfolder of the repository, rather than the root (as I understand it).

## Design

<!-- Why was this approach used? -->
Simplest, most straightforward approach I could think of.

## Changeset

<!-- What changed? -->
Added a `projectRoot` option that is propagated to `@bugsnag/source-maps`

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
We've been running this change using `patch-package` in building Docker Hub.