### PR TITLE
Bump tap-spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "once": "^1.4.0",
     "formidable": "^3.5.1",
     "standard": "^16.0.1",
-    "tap-spec": "^4.1.2",
+    "@randomgoods/tap-spec": "^5.0.4",
     "tape": "^5.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
## Goal

Bump tap-spec.

I moved to a fork with the updated dependencies because the original package is [no longer maintained](https://github.com/scottcorgan/tap-spec/issues/74#issuecomment-956044722).