### PR TITLE
[Fix] Improve regex to replace parent level path

### DIFF
--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -85,8 +85,8 @@ class BugsnagSourceMapUploaderPlugin {
             url: '' +
               // ensure publicPath has a trailing slash
               publicPath.replace(/[^/]$/, '$&/') +
-              // remove leading / or ./ from source
-              source.replace(/^\.?\//, '')
+              // remove leading / or ./ or ../ from source
+              source.replace(/^(\.\/|\.\.\/|\/)/, ""),
           }
         }).filter(Boolean)
       }


### PR DESCRIPTION
## Goal

Sometimes when passing `publicPath` the `source` is not prefixed with `/` or `./`, it can also happen to be prefixed with `../`. This PR improves the regex to also work on those cases.

## Changeset

* `source-map-uploader-plugin.js` 
