### PR TITLE
handle parent directory references in source paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- handle parent directory references in source paths (#85)
+
 ## [1.8.0] - 2021-07-07
 
 - Use webpack for logging (#55)

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -79,14 +79,19 @@ class BugsnagSourceMapUploaderPlugin {
             return null
           }
 
+          let url = '' +
+            // ensure publicPath has a trailing slash
+            publicPath.replace(/[^/]$/, '$&/') +
+            // remove leading / or ./ from source
+            source.replace(/^\.?\//, '')
+
+          // replace parent directory references with empty string
+          url = url.replace(/\.\.\//g, '')
+
           return {
             source: outputChunkLocation,
             map: outputSourceMapLocation,
-            url: '' +
-              // ensure publicPath has a trailing slash
-              publicPath.replace(/[^/]$/, '$&/') +
-              // remove leading / or ./ from source
-              source.replace(/^\.?\//, '')
+            url: url
           }
         }).filter(Boolean)
       }

--- a/test/fixtures/h/.gitignore
+++ b/test/fixtures/h/.gitignore
@@ -1,0 +1,3 @@
+static
+tmp
+dist

--- a/test/fixtures/h/src/index.js
+++ b/test/fixtures/h/src/index.js
@@ -1,0 +1,1 @@
+console.log('hi')

--- a/test/fixtures/h/webpack.config.js
+++ b/test/fixtures/h/webpack.config.js
@@ -1,0 +1,22 @@
+const BugsnagSourceMapUploaderPlugin = require('../../..').BugsnagSourceMapUploaderPlugin
+const webpack = require('webpack')
+
+module.exports = {
+  entry: './src/index.js',
+  devtool: false,
+  plugins: [
+    new webpack.SourceMapDevToolPlugin({
+      filename: '..tmp/[file].map'
+    }),
+    new BugsnagSourceMapUploaderPlugin({
+      apiKey: 'YOUR_API_KEY',
+      endpoint: `http://localhost:${process.env.PORT}`,
+      publicPath: 'https://foobar.com/js',
+    })
+  ],
+  output: {
+    // A chunk filename with a "../", as seen in nextjs projects
+    filename: '../static/chunks/[name].js',
+  },
+  mode: 'development',
+};


### PR DESCRIPTION
## Goal

In some circumstances chunk file paths can contain parent directory references (for example in https://github.com/bugsnag/webpack-bugsnag-plugins/issues/3#issuecomment-2424733506 and https://github.com/bugsnag/webpack-bugsnag-plugins/pull/80).

This change removes "../" from the produced `url`.

## Testing

- unit test
- tested against a new nextjs project (create-next-app) and verified source mapping working for server dynamic pages

Closes/fixes https://github.com/bugsnag/webpack-bugsnag-plugins/issues/3, https://github.com/bugsnag/webpack-bugsnag-plugins/pull/80