### PR TITLE
[PLAT-13824] Allow minifiedUrl to be specified in the webpack config

### DIFF
--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -81,12 +81,6 @@ class BugsnagSourceMapUploaderPlugin {
             return null
           }
 
-          // let url = '' +
-          //     // ensure publicPath has a trailing slash
-          //     publicPath.replace(/[^/]$/, '$&/') +
-          //     // remove leading / or ./ from source
-          //     source.replace(/^\.?\//, '')
-
           let url = this.minifiedUrl || (publicPath.replace(/[^/]$/, '$&/') + source.replace(/^\.\//, ''))
           // Check if this.minifyBundleUrls is set to true
           if (this.minifyBundleUrls) {

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -90,6 +90,7 @@ class BugsnagSourceMapUploaderPlugin {
           let url = this.minifiedUrl || (publicPath.replace(/[^/]$/, '$&/') + source.replace(/^\.\//, ''))
           // Check if this.minifyBundleUrls is set to true
           if (this.minifyBundleUrls) {
+            // replace hash in url with wildcard
             url = url.replace(/\.[a-f0-9]{8,}\./, '.*.')
           }
 

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -23,6 +23,8 @@ class BugsnagSourceMapUploaderPlugin {
     this.overwrite = options.overwrite
     this.endpoint = options.endpoint
     this.ignoredBundleExtensions = options.ignoredBundleExtensions || ['.css']
+    this.minifiedUrl = options.minifiedUrl
+    this.minifyBundleUrls = options.minifyBundleUrls
     this.validate()
   }
 
@@ -79,11 +81,17 @@ class BugsnagSourceMapUploaderPlugin {
             return null
           }
 
-          let url = '' +
-            // ensure publicPath has a trailing slash
-            publicPath.replace(/[^/]$/, '$&/') +
-            // remove leading / or ./ from source
-            source.replace(/^\.?\//, '')
+          // let url = '' +
+          //     // ensure publicPath has a trailing slash
+          //     publicPath.replace(/[^/]$/, '$&/') +
+          //     // remove leading / or ./ from source
+          //     source.replace(/^\.?\//, '')
+
+          let url = this.minifiedUrl || (publicPath.replace(/[^/]$/, '$&/') + source.replace(/^\.\//, ''))
+          // Check if this.minifyBundleUrls is set to true
+          if (this.minifyBundleUrls) {
+            url = url.replace(/\.[a-f0-9]{8,}\./, '.*.')
+          }
 
           // replace parent directory references with empty string
           url = url.replace(/\.\.\//g, '')
@@ -139,6 +147,7 @@ class BugsnagSourceMapUploaderPlugin {
     }
     if (this.endpoint) opts.endpoint = this.endpoint
     if (this.overwrite) opts.overwrite = this.overwrite
+
     return opts
   }
 


### PR DESCRIPTION
## Goal

Allow minifiedUrl to be specified in the webpack config.

```JS
new BugsnagSourceMapUploaderPlugin({
  apiKey: 'API_KEY',
  appVersion: '1.2.3',
  overwrite: true,
  minifiedUrl: 'https://your-app.xyz/assets/index.*.js',
})
```

Allow the plugin to remove the has from the minifiedUrl and replace it with a wildcard

```js
new BugsnagSourceMapUploaderPlugin({
  apiKey: 'API_KEY',
  appVersion: '1.2.3',
  overwrite: true,
  minifyBundleUrls: true,
})
```
Which results in the following files:

- admin.c4a4e18644e2987850b6.js
- app.c15535a32e266f5bc18d.js

Being uploaded as 

- admin.*.js
- app.*.js

## Testing

Tested locally with filename hashes and multiple chunks. Also covered by CI 