### PR TITLE
Call the `callback` when running the webpack plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.2.0] - 2025-05-13
 
-- Call the callbacks when running the source map upload and create build plugins (#94)
+- Call the callbacks when running the source map upload and create build plugins (#95)
 
 ## [2.1.0] - 2025-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.2.0] - 2025-05-13
+
+- Call the callbacks when running the source map upload and create build plugins (#94)
+
 ## [2.1.0] - 2025-05-12
 
 - Ensure that we pass overwrite and endpoint to the BugSnag CLI (#93)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [2.2.0] - 2025-05-13
 
-- Call the callbacks when running the source map upload and create build plugins (#95)
+- Ensure webpack plugin callback is called when running the source map upload and create build plugins (#95)
 
 ## [2.1.0] - 2025-05-12
 

--- a/build-reporter-plugin.js
+++ b/build-reporter-plugin.js
@@ -11,9 +11,9 @@ class BugsnagBuildReporterPlugin {
   }
 
   apply (compiler) {
-    const plugin = (compilation, cb) => {
+    const plugin = (compilation, callback) => {
       const stats = compilation.getStats()
-      if (stats.hasErrors()) return cb(null)
+      if (stats.hasErrors()) return callback(null)
       const logger = compiler.getInfrastructureLogger ? compiler.getInfrastructureLogger('BugsnagBuildReporterPlugin') : console
       const logPrefix = compiler.getInfrastructureLogger ? '' : `${LOG_PREFIX} `
       const cmdopts = this.getBuildOpts(this)
@@ -30,12 +30,14 @@ class BugsnagBuildReporterPlugin {
           output.split('\n').forEach((line) => {
             logger.info(`${logPrefix}${line}`)
           })
-        })
+          callback()
+        }, callback)
         .catch((error) => {
           // Split error by lines, prefix each line, and log them
           error.toString().split('\n').forEach((line) => {
             logger.error(`${logPrefix}${line}`)
           })
+          callback()
         })
     }
 


### PR DESCRIPTION
## Goal

Currently, we're not calling the `callback` in the webpack plugins, which is prematurely causing the webpack to exit. This change ensures we're calling the callback within each plugin

## Testing

Tested using multiple versions of webpack locally 