### PR TITLE
Ensure we have all the BugSnag CLI options available in the webpack plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.2.1] - 2025-05-22
+
+- Ensure we expose all options in the Webpack plugin that are available in the Bugsnag CLI (#99)
+- Allow BugsnagBuildReporterPlugin to pass all options in a single object (#99)
+
 ## [2.2.0] - 2025-05-13
 
 - Ensure webpack plugin callback is called when running the source map upload and create build plugins (#95)

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -25,6 +25,11 @@ class BugsnagSourceMapUploaderPlugin {
     this.bundle = options.bundle
     this.bundleUrl = options.bundleUrl
     this.ignoredBundleExtensions = options.ignoredBundleExtensions || ['.css']
+    this.dryRun = options.dryRun
+    this.logLevel = options.logLevel
+    this.verbose = options.verbose
+    this.retries = options.retries
+    this.timeout = options.timeout
     this.validate()
   }
 
@@ -133,12 +138,6 @@ class BugsnagSourceMapUploaderPlugin {
   }
 
   bugsnagCliUploadOpts (sm) {
-    // Validate required fields
-    if (!this.apiKey) {
-      console.error('Error: API key is required but was not provided.')
-      return null
-    }
-
     // Command base
     const cmdOpts = {
       apiKey: this.apiKey,
@@ -153,7 +152,12 @@ class BugsnagSourceMapUploaderPlugin {
       sourceMap: sm.map,
       bundle: this.bundle || sm.source,
       codeBundleId: this.codeBundleId,
-      overwrite: this.overwrite
+      overwrite: this.overwrite,
+      dryRun: this.dryRun,
+      logLevel: this.logLevel,
+      verbose: this.verbose,
+      retries: this.retries,
+      timeout: this.timeout
     }
 
     for (const [key, value] of Object.entries(optionalParams)) {


### PR DESCRIPTION
## Goal

- Ensure we expose all options in the Webpack plugin that are available in the Bugsnag CLI
- Allow BugsnagBuildReporterPlugin to pass all options in a single object

## Testing

Covered by CI 