### PR TITLE
Fix a bug with build metadata option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [Unreleased]
+
+- Fixed an issue when build metadata option is not provided (#101)
+
 ## [2.2.2] - 2025-07-03
 
 - Ensure that we correctly pass the metadata the BugSnag CLI create build command (#100)

--- a/build-reporter-plugin.js
+++ b/build-reporter-plugin.js
@@ -65,7 +65,7 @@ class BugsnagBuildReporterPlugin {
       metadata: opts.build.metadata
         ? Object.entries(opts.build.metadata)
             .map(([key, value]) => `${key}=${value}`)
-            .join(',')
+            .join(';')
         : undefined,
       provider: opts.build.sourceControl.provider,
       repository: opts.build.sourceControl.repository,

--- a/build-reporter-plugin.js
+++ b/build-reporter-plugin.js
@@ -65,7 +65,7 @@ class BugsnagBuildReporterPlugin {
       metadata: opts.build.metadata
         ? Object.entries(opts.build.metadata)
             .map(([key, value]) => `${key}=${value}`)
-            .join(';')
+            .join(',')
         : undefined,
       provider: opts.build.sourceControl.provider,
       repository: opts.build.sourceControl.repository,

--- a/build-reporter-plugin.js
+++ b/build-reporter-plugin.js
@@ -62,9 +62,9 @@ class BugsnagBuildReporterPlugin {
     const optionalOpts = {
       autoAssignRelease: opts.build.autoAssignRelease,
       builderName: opts.build.builderName,
-      metadata: Object.entries(opts.build.metadata)
+      metadata: opts.build.metadata ? Object.entries(opts.build.metadata)
         .map(([key, value]) => `${key}=${value}`)
-        .join(','),
+        .join(',') : undefined,
       provider: opts.build.sourceControl.provider,
       repository: opts.build.sourceControl.repository,
       revision: opts.build.sourceControl.revision,

--- a/build-reporter-plugin.js
+++ b/build-reporter-plugin.js
@@ -62,9 +62,11 @@ class BugsnagBuildReporterPlugin {
     const optionalOpts = {
       autoAssignRelease: opts.build.autoAssignRelease,
       builderName: opts.build.builderName,
-      metadata: opts.build.metadata ? Object.entries(opts.build.metadata)
-        .map(([key, value]) => `${key}=${value}`)
-        .join(',') : undefined,
+      metadata: opts.build.metadata
+        ? Object.entries(opts.build.metadata)
+            .map(([key, value]) => `${key}=${value}`)
+            .join(',')
+        : undefined,
       provider: opts.build.sourceControl.provider,
       repository: opts.build.sourceControl.repository,
       revision: opts.build.sourceControl.revision,

--- a/package.json
+++ b/package.json
@@ -19,14 +19,10 @@
   "devDependencies": {
     "@randomgoods/tap-spec": "^5.0.4",
     "concat-stream": "^1.6.2",
-    "css-loader": "^7.1.2",
     "formidable": "^3.5.1",
-    "mini-css-extract-plugin": "^2.9.2",
     "once": "^1.4.0",
     "standard": "^16.0.1",
-    "tape": "^5.0.1",
-    "webpack": "^5.99.9",
-    "webpack-cli": "^6.0.1"
+    "tape": "^5.0.1"
   },
   "dependencies": {
     "@bugsnag/cli": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
   "devDependencies": {
     "@randomgoods/tap-spec": "^5.0.4",
     "concat-stream": "^1.6.2",
+    "css-loader": "^7.1.2",
     "formidable": "^3.5.1",
+    "mini-css-extract-plugin": "^2.9.2",
     "once": "^1.4.0",
     "standard": "^16.0.1",
     "tape": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
   "author": "Bugsnag Inc.",
   "license": "MIT",
   "devDependencies": {
-    "concat-stream": "^1.6.2",
-    "once": "^1.4.0",
-    "formidable": "^3.5.1",
-    "standard": "^16.0.1",
     "@randomgoods/tap-spec": "^5.0.4",
-    "tape": "^5.0.1"
+    "concat-stream": "^1.6.2",
+    "formidable": "^3.5.1",
+    "once": "^1.4.0",
+    "standard": "^16.0.1",
+    "tape": "^5.0.1",
+    "webpack": "^5.99.9",
+    "webpack-cli": "^6.0.1"
   },
   "dependencies": {
     "@bugsnag/cli": "^3.0.0",

--- a/test/build-reporter-plugin.test.mjs
+++ b/test/build-reporter-plugin.test.mjs
@@ -41,10 +41,19 @@ test('it sends upon successful build', t => {
     })
   })
   server.listen()
+
+  // Add timeout to prevent hanging
+  const timeout = setTimeout(() => {
+    server.close()
+    t.fail('Test timed out - webpack process may be hanging')
+    t.end()
+  }, 30000) // 30 second timeout
+
   exec(join(__dirname, '..', 'node_modules', '.bin', 'webpack'), {
     env: generateEnv(server),
     cwd: join(__dirname, 'fixtures', 'a')
   }, (err, stdout, stderr) => {
+    clearTimeout(timeout)
     server.close()
     if (err) { console.info(err, '\n\n\n', stdout, '\n\n\n', stderr) }
     if (err) return t.fail(err.message)
@@ -62,12 +71,21 @@ test('it doesn’t send upon unsuccessful build', t => {
     })
   })
   server.listen()
+
+  // Add timeout to prevent hanging
+  const timeout = setTimeout(() => {
+    server.close()
+    t.fail('Test timed out - webpack process may be hanging')
+    t.end()
+  }, 30000) // 30 second timeout
+
   exec(join(__dirname, '..', 'node_modules', '.bin', 'webpack'), {
     env: generateEnv(server),
     cwd: join(__dirname, 'fixtures', 'b')
   }, (err, stdout, stderr) => {
+    clearTimeout(timeout)
     server.close()
-    t.ok(err)
+    t.ok(err, 'webpack should fail due to syntax error')
     t.end()
   })
 })

--- a/test/fixtures/i/.gitignore
+++ b/test/fixtures/i/.gitignore
@@ -1,0 +1,1 @@
+bundle.js

--- a/test/fixtures/i/app.js
+++ b/test/fixtures/i/app.js
@@ -1,0 +1,1 @@
+console.log('hello world without metadata')

--- a/test/fixtures/i/webpack.config.js
+++ b/test/fixtures/i/webpack.config.js
@@ -1,0 +1,17 @@
+const BugsnagBuildReporterPlugin = require('../../../').BugsnagBuildReporterPlugin
+
+module.exports = {
+  entry: './app.js',
+  output: {
+    path: __dirname,
+    filename: './bundle.js'
+  },
+  plugins: [
+    new BugsnagBuildReporterPlugin({
+      apiKey: 'YOUR_API_KEY',
+      appVersion: '1.2.3',
+      endpoint: `http://localhost:${process.env.PORT}`
+      // Note: no metadata provided
+    })
+  ]
+}

--- a/test/source-map-uploader-plugin.test.mjs
+++ b/test/source-map-uploader-plugin.test.mjs
@@ -197,8 +197,8 @@ if (process.env.WEBPACK_VERSION !== '3') {
 
       const done = () => {
         t.equal(requests[0].minifiedUrl, '*/dist/main.js')
-        t.match(requests[0].parts[1].filename, /main\.js$/)
-        t.match(requests[0].parts[0].filename, /main\.js\.map$/)
+        t.match(requests[0].parts.find(p => p.filename.includes('.js') && !p.filename.includes('.map'))?.filename, /main\.js$/)
+        t.match(requests[0].parts.find(p => p.filename.includes('.js.map'))?.filename, /main\.js\.map$/)
         end()
       }
 

--- a/test/source-map-uploader-plugin.test.mjs
+++ b/test/source-map-uploader-plugin.test.mjs
@@ -246,11 +246,11 @@ if (process.env.WEBPACK_VERSION !== '3') {
     const done = () => {
       requests.sort((a, b) => a.minifiedUrl < b.minifiedUrl ? -1 : 1)
       t.equal(requests[0].minifiedUrl, '*/dist/main.css')
-      t.match(requests[0].parts[0].filename, /main\.css/)
-      t.match(requests[0].parts[0].filename, /main\.css\.map/)
+      t.match(requests[0].parts.find(p => p.filename.includes('.css'))?.filename, /main\.css/)
+      t.match(requests[0].parts.find(p => p.filename.includes('.map'))?.filename, /main\.css\.map/)
       t.equal(requests[1].minifiedUrl, '*/dist/main.js')
-      t.match(requests[1].parts[0].filename, /main\.js/)
-      t.match(requests[1].parts[0].filename, /main\.js\.map/)
+      t.match(requests[1].parts.find(p => p.filename.includes('.js') && !p.filename.includes('.map'))?.filename, /main\.js/)
+      t.match(requests[1].parts.find(p => p.filename.includes('.js.map'))?.filename, /main\.js\.map/)
       end()
     }
 


### PR DESCRIPTION
## Goal

Fix a bug with attempting to access optional build metadata when it has not been provided

This PR also loosens the test assertions by not requiring a specific order

## Testing

Add a new test scenario for a successful build with missing metadata