### PR TITLE
remove bypassable url.replace(/../) sanitization — url is passed to @…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unrelease]
+
+### Fixed
+
+- SAST fix-Remove bypassable url.replace(/../) sanitization — url is passed to @bugsnag/cli, not used in any injection-sensitive context (#103)
+
 ## [2.2.3] - 2025-07-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## [Unrelease]
-
-### Fixed
-
-- SAST fix-Remove bypassable url.replace(/../) sanitization — url is passed to @bugsnag/cli, not used in any injection-sensitive context (#103)
-
 ## [2.2.3] - 2025-07-08
 
 ### Fixed

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -92,9 +92,6 @@ class BugsnagSourceMapUploaderPlugin {
             // remove leading / or ./ from source
             source.replace(/^\.?\//, '')
 
-          // replace parent directory references with empty string
-          url = url.replace(/\.\.\//g, '')
-
           return {
             source: outputChunkLocation,
             map: outputSourceMapLocation,

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -86,7 +86,7 @@ class BugsnagSourceMapUploaderPlugin {
             return null
           }
 
-          let url = '' +
+          const url = '' +
             // ensure publicPath has a trailing slash
             publicPath.replace(/[^/]$/, '$&/') +
             // remove leading / or ./ from source

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -92,8 +92,22 @@ class BugsnagSourceMapUploaderPlugin {
             // remove leading / or ./ from source
             source.replace(/^\.?\//, '')
 
-          // Normalize path segments (e.g. "../") using URL API to fix CWE-116
-          url = new URL(url).href
+          // Normalize path segments (e.g. "../") to fix CWE-116 path traversal.
+          // Use URL API for absolute URLs, segment resolution for relative paths.
+          try {
+            url = new URL(url).href
+          } catch (e) {
+            const parts = url.split('/')
+            const resolved = []
+            for (const part of parts) {
+              if (part === '..') {
+                resolved.pop()
+              } else {
+                resolved.push(part)
+              }
+            }
+            url = resolved.join('/')
+          }
 
           return {
             source: outputChunkLocation,

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -92,21 +92,10 @@ class BugsnagSourceMapUploaderPlugin {
             // remove leading / or ./ from source
             source.replace(/^\.?\//, '')
 
-          // Normalize path segments (e.g. "../") to fix CWE-116 path traversal.
-          // Use URL API for absolute URLs, segment resolution for relative paths.
-          try {
-            url = new URL(url).href
-          } catch (e) {
-            const parts = url.split('/')
-            const resolved = []
-            for (const part of parts) {
-              if (part === '..') {
-                resolved.pop()
-              } else {
-                resolved.push(part)
-              }
-            }
-            url = resolved.join('/')
+          // Remove "../" path traversal segments from the URL. Loop ensures
+          // bypass attempts like "....//  " are fully resolved (fixes CWE-116).
+          while (url.includes('../')) {
+            url = url.replace(/\.\.\//g, '')
           }
 
           return {

--- a/source-map-uploader-plugin.js
+++ b/source-map-uploader-plugin.js
@@ -86,11 +86,14 @@ class BugsnagSourceMapUploaderPlugin {
             return null
           }
 
-          const url = '' +
+          let url = '' +
             // ensure publicPath has a trailing slash
             publicPath.replace(/[^/]$/, '$&/') +
             // remove leading / or ./ from source
             source.replace(/^\.?\//, '')
+
+          // Normalize path segments (e.g. "../") using URL API to fix CWE-116
+          url = new URL(url).href
 
           return {
             source: outputChunkLocation,


### PR DESCRIPTION
…bugsnag/cli, not used in any injection-sensitive context

## Goal

Remediate a high-severity SAST (Static Application Security Testing) finding in the bugsnag/webpack-bugsnag-plugins repository

## Changeset

Remove line 96 (url = url.replace(/\.\.\//g, '')) from source-map-uploader-plugin.js

## Testing

Did UT